### PR TITLE
feat: add keyboard and gamepad bindings to inputs

### DIFF
--- a/src/button.scss
+++ b/src/button.scss
@@ -34,10 +34,6 @@
         }
     }
 
-    &.active {
-      background: #f00;
-    }
-
     // The disabled class is applied when the input gets disabled.
     &[disabled] {
         opacity: 0.7;

--- a/src/button.tsx
+++ b/src/button.tsx
@@ -199,14 +199,9 @@ export class Button extends PreactControl<{ availableSparks: number; active: boo
   protected registerGamepadButton() {
     if (this.disabled) {
       this.gamepad.unregisterButtonListener(this.gamepadButtonPress);
-      return;
+    } else if (typeof this.gamepadButton === 'number') {
+      this.gamepad.registerButtonListener(this.gamepadButton, this.gamepadButtonPress);
     }
-
-    this.gamepad.registerButtonListener({
-      boundButton: this.gamepadButton,
-      keyCode: this.keyCode,
-      listener: this.gamepadButtonPress,
-    });
   }
 
   protected mousedown = () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
 import * as Mixer from '@mcph/miix-std';
 import { h, render } from 'preact';
 
-import { Button, gamepad } from './alchemy/Gamepad';
 import { PreactScene, PreactStage } from './alchemy/preact/index';
 import { Button as ButtonControl } from './button';
 import { Joystick as JoystickControl } from './joystick';
@@ -12,25 +11,6 @@ require('./style.scss');
 // The registry contains a list of all your custom scenes and buttons. You
 // should pass them in here so that we're aware of them!
 const registry = new Mixer.Registry().register(ButtonControl, JoystickControl, PreactScene);
-
-// We can automatically translate Xbox controller input to keyboard inputs.
-// You can configure these bindings here. Note that in controls you can
-// can explicitly bind to a button or joystick, doing this will override
-// these default bindings.
-gamepad.bindJoysticks(true).bindButtons({
-  [Button.Y]: 'W',
-  [Button.X]: 'A',
-  [Button.A]: 'S',
-  [Button.B]: 'D',
-  [Button.LeftBumper]: 'Q',
-  [Button.LeftTrigger]: 'Q',
-  [Button.RightBumper]: 'E',
-  [Button.RightTrigger]: 'E',
-  [Button.DPadUp]: 38,
-  [Button.DPadRight]: 39,
-  [Button.DPadDown]: 40,
-  [Button.DPadLeft]: 41,
-});
 
 // Do the thing!
 render(<PreactStage registry={registry} />, document.querySelector('#app'));

--- a/src/joystick.tsx
+++ b/src/joystick.tsx
@@ -153,8 +153,7 @@ export class Joystick extends PreactControl {
 
   /**
    * Gamepad joystick number to bind to. On Xbox, `0` is the left stick and
-   * `1` is the right stick. The joystick will bind automatically if this
-   * isn't set.
+   * `1` is the right stick.
    */
   @Mixer.Input() public gamepadJoystick: number;
 
@@ -199,13 +198,9 @@ export class Joystick extends PreactControl {
   protected registerGamepadJoysticks() {
     if (this.disabled) {
       this.gamepad.unregisterJoystickListener(this.gamepadJoystickMove);
-      return;
+    } else if (typeof this.gamepadJoystick === 'number') {
+      this.gamepad.registerJoystickListener(this.gamepadJoystick, this.gamepadJoystickMove);
     }
-
-    this.gamepad.registerJoystickListener({
-      boundIndex: this.gamepadJoystick,
-      listener: this.gamepadJoystickMove,
-    });
   }
 
   protected setJoystick = (element: HTMLElement) => {


### PR DESCRIPTION
Resolves [4494 ](https://watchmixer.visualstudio.com//Mixer/_workitems/edit/4494)

The general idea is that we auto-bind by default, but if we see that people have set up explicit bindings we take our hands off. Definitely not the prettiest code here but it seems functional. I'll probably go back around and write unit tests this weekend or something.

Joystick demo: https://peet.io/i/17-09-e0033956dwpngjdeqikl7bmb79iqct.mp4. What you see:
 - Joysticks that are disabled are not auto-bound
 - When a joystick is reenabled it's re-bound, as you should expect
 - When a joystick is auto-bound, it takes precedent over auto-bound joysticks

Button demo: https://peet.io/i/17-09-ukl149pflgp3cav5e24h1ioscc8ehn.mp4. What you see:
 - Buttons bind by their keyCode by default. In this case I was pressing "A" on the controller
 - If there is a button that explicitly "asks" for a joystick button, we won't auto-bind to that joystick button
 - I didn't show it, but disabled buttons are also unbound

