### PR TITLE
feat(alchemy+prefab): add HTML control and control prefab

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "interactive": {
     "display": {
-      "mode": "fixed-grid"
+      "mode": "flex"
     }
   },
   "author": "Connor Peet <connor@peet.io>",
@@ -24,7 +24,7 @@
     "preact": "^8.2.1"
   },
   "devDependencies": {
-    "@mcph/miix-cli": "0.1.0-alpha.9",
+    "@mcph/miix-cli": "^0.1.1",
     "@types/node": "^8.0.24",
     "awesome-typescript-loader": "^3.2.2",
     "clean-webpack-plugin": "^0.1.16",

--- a/src/alchemy/preact/HtmlControl.tsx
+++ b/src/alchemy/preact/HtmlControl.tsx
@@ -1,0 +1,167 @@
+import { h } from 'preact';
+import { log } from '../Log';
+
+import { PreactControl } from './Control';
+
+/**
+ * regex for moving CDATA tags around scripts for our insertion.
+ */
+const cdataRe = /^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g;
+
+/**
+ * The HtmlControl can be extended to allow you insert snippets or HTML
+ * elements directly into the page. It has a getHtml() function that you
+ * must implement, along with helper functions to load files or URLs.
+ *
+ * For example, to place a string of HTML:
+ *
+ * ```
+ * export class GreeterControl extends HtmlControl {
+ *   public componentDidMount() {
+ *     this.insert('<h1>Hello world!</h1>');
+ *   }
+ * }
+ * ```
+ *
+ * You can also load external HTML pages. If you're loading off an external
+ * domain, make sure that the page has the necessary security headers to let
+ * you request it. (See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+ *
+ * ```
+ * export class GreeterControl extends HtmlControl {
+ *   public componentDidMount() {
+ *     this.insertUrl('https://example.com/my-greeter-control.html');
+ *   }
+ * }
+ * ```
+ *
+ * Finally, you can load HTML contents straight from the disk. For example,
+ * if you had a folder like:
+ *
+ * ```
+ * src/prefabs/my-greeter-control
+ * ├── greeter.html
+ * └── greeter.tsx
+ * ```
+ *
+ * You can import and include `greeter.html` from `greeter.tsx` via:
+ *
+ * ```
+ * export class GreeterControl extends HtmlControl {
+ *   public componentDidMount() {
+ *     this.insertUrl(require('./greeter.html'));
+ *   }
+ * }
+ * ```
+ *
+ * This is a Preact control, so you can, as usual, hook into the various
+ * lifecycle methods: https://preactjs.com/guide/api-reference#lifecycle-methods
+ */
+export abstract class HtmlControl<T = {}> extends PreactControl<T> {
+  /**
+   * The ID for this control, see getId() for more information.
+   */
+  protected readonly id = this.getId();
+
+  /**
+   * boundElement is a list of HTML elements--scripts and style tags--appended
+   * globally to the document which should be cleaned up when the control
+   * is removed.
+   */
+  private boundElements: Element[] = [];
+
+  /**
+   * @override on Preact's render method.
+   */
+  public render() {
+    return <div id={this.id} />;
+  }
+
+  /**
+   * @override on Preact's component teardown.
+   */
+  public componentWillUnmount() {
+    this.unmount();
+  }
+
+  /**
+   * Returns a unique ID for this control. Your HTML contents will be put
+   * inside a div with this ID, like `<div id="my-id"></div>`. You can
+   * use this in business logic you may have to scope the specific control.
+   * This should have some random component in case there are multiple HTML
+   * controls in the scene.
+   */
+  protected getId(): string {
+    return `html-control-${Math.random()}`;
+  }
+
+  /**
+   * Loads HTML from the provided address into the control.
+   * See the docs on the HtmlControl class for more information and examples.
+   */
+  protected insertUrl(address: string): Promise<void> {
+    return fetch(address)
+      .then(response => response.text())
+      .then(text => this.insert(text))
+      .catch(err => {
+        log.error(err, 'Error loading external HTML control content from:', address);
+        throw err;
+      });
+  }
+
+  /**
+   * insert adds the loaded template into the DOM. Internally it handles
+   * extractions of scripts and styles so that the browser correctly executes
+   * them.
+   */
+  protected insert(contents: string | Element) {
+    this.unmount();
+
+    const container = this.base;
+    if (typeof contents === 'string') {
+      // tslint:disable-next-line
+      container.innerHTML = contents;
+    } else {
+      container.appendChild(contents);
+    }
+
+    const toExtract = [
+      ...Array.from(container.querySelectorAll('link[rel="stylesheet"], link[type="text/css"]')),
+      ...Array.from(container.getElementsByTagName('style')),
+      ...Array.from(container.getElementsByTagName('script')),
+    ];
+
+    this.boundElements = toExtract.map(el => {
+      if (el.parentElement) {
+        el.parentElement.removeChild(el);
+      }
+
+      if (el instanceof HTMLScriptElement) {
+        const script = document.createElement('script');
+        script.text = el.text.replace(cdataRe, '');
+        return document.head.appendChild(script);
+      }
+
+      document.head.appendChild(el);
+      return el;
+    });
+  }
+
+  /**
+   * Removes all elements and bound document scripts associated with the
+   * rendered content.
+   */
+  protected unmount() {
+    this.boundElements.forEach(el => {
+      if (el.parentElement) {
+        el.parentElement.removeChild(el);
+      }
+    });
+
+    while (this.base.firstChild) {
+      this.base.removeChild(this.base.firstChild);
+    }
+
+    this.boundElements = [];
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 import * as Mixer from '@mcph/miix-std';
 import { h, render } from 'preact';
+import { HtmlStringControl } from './prefabs/html/html';
 
 import { PreactStage } from './alchemy/preact/index';
 import { Button as ButtonControl } from './prefabs/button/button';
@@ -11,7 +12,12 @@ require('./style.scss');
 
 // The registry contains a list of all your custom scenes and buttons. You
 // should pass them in here so that we're aware of them!
-const registry = new Mixer.Registry().register(ButtonControl, JoystickControl, DefaultScene);
+const registry = new Mixer.Registry().register(
+  HtmlStringControl,
+  ButtonControl,
+  JoystickControl,
+  DefaultScene,
+);
 
 // Do the thing!
 render(<PreactStage registry={registry} />, document.querySelector('#app'));

--- a/src/prefabs/html/html.tsx
+++ b/src/prefabs/html/html.tsx
@@ -1,0 +1,53 @@
+import * as Mixer from '@mcph/miix-std';
+
+import { HtmlControl } from '../../alchemy/preact/HtmlControl';
+
+/**
+ * The SimpleHtmlControl simply renders HTML provided in the given string
+ * or external URL.
+ *
+ * If you're customizing your bundle, you can also swap this to import a local
+ * file, by passing it into the `url` method. This can look something like:
+ *
+ * ```
+ *   public getHtml() {
+ *     return this.url(require('./hello-world.html'));
+ *   }
+ * ```
+ */
+@Mixer.Control({ kind: 'htmlString' })
+export class HtmlStringControl extends HtmlControl {
+  /**
+   * htmlString is a string of HTML data. Either this, or htmlUrl, should be set.
+   */
+  @Mixer.Input() public htmlString: string = '';
+
+  /**
+   * htmlUrl is a web page to load HTML data from.
+   * Either this, or htmlString, should be set.
+   */
+  @Mixer.Input({ kind: Mixer.InputKind.Url })
+  public htmlUrl: string = '';
+
+  /**
+   * @override
+   */
+  public componentDidMount() {
+    this.renderHtml();
+  }
+
+  /**
+   * @override
+   */
+  public componentDidUpdate() {
+    this.renderHtml();
+  }
+
+  private renderHtml() {
+    if (this.htmlUrl) {
+      this.insertUrl(this.htmlUrl);
+    } else {
+      this.insert(this.htmlString);
+    }
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -24,6 +24,7 @@
     "promise-function-async": false,
     "no-void-expression": false,
     "no-use-before-declare": false,
+    "no-floating-promises": false,
 
     // Prettier-incompatible or prettier-handled rules
     "align": false,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -98,6 +98,14 @@ module.exports = {
           'sass-loader',
         ],
       },
+      // Allow importing html and svg files directly, for the HtmlControl.
+      // See the docs and examples in the HtmlControl for more info!
+      {
+        test: /\.(html|svg)$/,
+        loaders: [
+          'file-loader',
+        ],
+      },
     ],
   },
   externals: {


### PR DESCRIPTION
Seem to work. Adds a "base" HTML control and a prefab that can load strings or URLs. Demo:

https://peet.io/i/17-11-173mztkx5o6kwt8b9tr5sg84l78b68.mp4