### PR TITLE
fix(button): Cooldown not starting at sent value, counts down an extra initial second, getting stuck on 1s

### DIFF
--- a/src/prefabs/button/button.tsx
+++ b/src/prefabs/button/button.tsx
@@ -74,7 +74,7 @@ export class CoolDown extends Component<{ cooldown: number }, { ttl: number }> {
   public render() {
     return (
       <div class={classes({ mixerCooldown: true, active: this.state.ttl > 0 })}>
-        <div>{this.state.ttl}s</div>
+        <div>{this.state.ttl + 1}s</div>
       </div>
     );
   }
@@ -86,7 +86,7 @@ export class CoolDown extends Component<{ cooldown: number }, { ttl: number }> {
     // second. This keeps the timeout from "flickering" and make sure it
     // counts perfectly down to 1. (Intervals will fire later, but never
     // earlier, than the specified time.)
-    let remaining = Math.round(delta / 1000);
+    let remaining = Math.floor(delta / 1000);
     const timeout = setTimeout(() => {
       const interval = setInterval(() => {
         if (remaining === 0) {
@@ -97,8 +97,6 @@ export class CoolDown extends Component<{ cooldown: number }, { ttl: number }> {
       this.setState({ ...this.state, ttl: remaining-- });
       this.cancel = () => clearInterval(interval);
     }, delta % 1000);
-
-    this.setState({ ...this.state, ttl: remaining-- });
     this.cancel = () => clearTimeout(timeout);
   }
 }


### PR DESCRIPTION
Resolves various issues related to cooldowns on buttons.

https://watchmixer.visualstudio.com/Mixer/_workitems?id=6953
https://watchmixer.visualstudio.com/Mixer/_workitems?id=6985
https://watchmixer.visualstudio.com/Mixer/_workitems?id=6979