### PR TITLE
refactor(alchemy): update settings to use the observable from std

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "decko": "^1.2.0",
     "eventemitter3": "^2.0.3",
     "intl-messageformat": "^2.1.0",
-    "preact": "^8.2.1"
+    "preact": "^8.2.1",
+    "rxjs": "^5.5.6"
   },
   "devDependencies": {
     "@mcph/miix-cli": "^0.2.0",

--- a/src/alchemy/Locales.ts
+++ b/src/alchemy/Locales.ts
@@ -25,7 +25,7 @@ export class Locales extends EventEmitter {
    */
   public bindListeners(): this {
     this.loadLocaleFromSettings(Mixer.display.getSettings());
-    Mixer.display.on('settings', s => this.loadLocaleFromSettings(s));
+    Mixer.display.settings().subscribe(s => this.loadLocaleFromSettings(s));
     return this;
   }
 

--- a/src/alchemy/Style.tsx
+++ b/src/alchemy/Style.tsx
@@ -122,7 +122,8 @@ class PlacesVideoMatcher implements IQueryMatcher {
    * @override
    */
   public matches(): boolean {
-    const places = display.getSettings().placesVideo;
+    const settings = display.getSettings();
+    const places = settings && settings.placesVideo;
     const matches = PlacesVideoMatcher.pattern.exec(this.query);
     const expected = matches && matches[1] === 'true';
     return expected === places;
@@ -132,9 +133,8 @@ class PlacesVideoMatcher implements IQueryMatcher {
    * @override
    */
   public watch(fn: (matches: boolean) => void): () => void {
-    const handler = () => fn(this.matches());
-    display.on('settings', handler);
-    return () => display.removeListener('settings', handler);
+    const subscription = display.settings().subscribe(() => fn(this.matches()));
+    return () => subscription.unsubscribe();
   }
 }
 

--- a/src/alchemy/Toolbox.ts
+++ b/src/alchemy/Toolbox.ts
@@ -1,3 +1,7 @@
+import { Component } from 'preact';
+import { takeUntil } from 'rxjs/operators';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+
 /**
  * throttle creates a function that calls the inner, passed function at
  * the trailing edge of the throttle duration, with the last set of
@@ -21,4 +25,27 @@ export function throttle<T extends Function>(duration: number, fn: T): T {
       fn.apply(this, lastArgs);
     }, duration);
   };
+}
+
+/**
+ * untilUnmount returns a function that can be used in an observable's pipe
+ * to unsubscribe.
+ *
+ * @example
+ * mixer.display.video()
+ *   .pipe(untilUnmount(this))
+ *   .subscribe(settings => this.updateSettings(settings));
+ */
+export function untilUnmount(component: Component<any, any>) {
+  const inner = component.componentWillUnmount;
+  const notifier = new ReplaySubject<void>(1);
+  component.componentWillMount = function() {
+    notifier.next(undefined);
+    if (inner) {
+      // tslint:disable-next-line
+      inner.apply(this, arguments);
+    }
+  };
+
+  return takeUntil(notifier);
 }

--- a/src/alchemy/preact/Layout.tsx
+++ b/src/alchemy/preact/Layout.tsx
@@ -4,12 +4,14 @@
  */
 
 import { display, ISettings, Layout } from '@mcph/miix-std';
-import { bind, debounce } from 'decko';
 import { Component, h } from 'preact';
+import { fromEvent } from 'rxjs/observable/fromEvent';
+import { debounceTime, startWith } from 'rxjs/operators';
 
 import { log } from '../Log';
 import { MControl, MScene } from '../State';
 import { css, RuleSet } from '../Style';
+import { untilUnmount } from '../Toolbox';
 import { PreactControl } from './Control';
 import { ResourceHolder } from './Helpers';
 
@@ -243,16 +245,10 @@ export class FlexLayout extends Component<ILayoutOptions, {}> implements ILayout
 
   private container: FlexContainer;
 
-  public componentWillMount() {
-    window.addEventListener('resize', this.resizeListener);
-  }
-
   public componentDidMount() {
-    this.refresh();
-  }
-
-  public componentWillUnmount() {
-    window.removeEventListener('resize', this.resizeListener);
+    fromEvent(window, 'resize')
+      .pipe(debounceTime(5), untilUnmount(this), startWith(null))
+      .subscribe(() => this.refresh());
   }
 
   public componentDidUpdate() {
@@ -304,12 +300,6 @@ export class FlexLayout extends Component<ILayoutOptions, {}> implements ILayout
   private setContainer = (container: FlexContainer) => {
     this.container = container;
   };
-
-  @bind
-  @debounce(5)
-  private resizeListener() {
-    this.refresh();
-  }
 }
 
 export interface IFlexContainerOptions {

--- a/src/alchemy/preact/Scene.tsx
+++ b/src/alchemy/preact/Scene.tsx
@@ -1,8 +1,8 @@
 import * as Mixer from '@mcph/miix-std';
-import { bind } from 'decko';
 import { Component } from 'preact';
 
 import { MScene } from '../State';
+import { untilUnmount } from '../Toolbox';
 import { FixedGridLayout, FlexLayout } from './Layout';
 
 export type SceneProps<S> = { resource: MScene<S & Mixer.IScene> } & S & Mixer.IScene;
@@ -25,15 +25,12 @@ export abstract class PreactScene<T, S = {}> extends Component<
    * @override
    */
   public componentWillMount() {
-    this.updateSettings();
-    Mixer.display.on('settings', this.updateSettings);
-  }
-
-  /**
-   * @override
-   */
-  public componentWillUnmount() {
-    Mixer.display.removeListener('settings', this.updateSettings);
+    Mixer.display
+      .settings()
+      .pipe(untilUnmount(this))
+      .subscribe(settings => {
+        this.setState(Object.assign({}, this.state, { settings }));
+      });
   }
 
   /**
@@ -52,10 +49,5 @@ export abstract class PreactScene<T, S = {}> extends Component<
     }
 
     return FixedGridLayout;
-  }
-
-  @bind
-  private updateSettings() {
-    this.setState(Object.assign({}, this.state, { settings: Mixer.display.getSettings() }));
   }
 }


### PR DESCRIPTION
Lower priority thing since the changes in the standard library are non-breaking. Decided to bit the bullet and grab rxjs since it makes certain things _way_ easier and more natural. This converts the settings from their previous eventemitter style to be observables.