### PR TITLE
Add Translate to exports in alchemy/preact

### DIFF
--- a/src/alchemy/preact/index.tsx
+++ b/src/alchemy/preact/index.tsx
@@ -13,3 +13,4 @@ export * from './Control';
 export * from './Scene';
 export * from './SparkPill';
 export * from './Stage';
+export * from './Translate';


### PR DESCRIPTION
The tutorial uses this module, but it is not exported.