### PR TITLE
Fix/Add Translate to exports in alchemy/preact

### DIFF
--- a/src/alchemy/preact/index.tsx
+++ b/src/alchemy/preact/index.tsx
@@ -13,3 +13,4 @@ export * from './Control';
 export * from './Scene';
 export * from './SparkPill';
 export * from './Stage';
+export * from './Translate';


### PR DESCRIPTION
Translate module is used in the tutorial, but is not exported.