### PR TITLE
address focus issue for screen controls

### DIFF
--- a/src/prefabs/screen/screen.scss
+++ b/src/prefabs/screen/screen.scss
@@ -4,9 +4,10 @@
 	left: 5%;
 	height: 50px;
 	width: 50px;
-	background: url(./static/cursor.png) no-repeat 0 0 /contain;
+  background: url(./static/cursor.png) no-repeat 0 0 /contain;
+  outline: none;
 }
-  
+
 .mixer-click-visual {
 	position: relative;
 	display: inline-block;
@@ -41,10 +42,10 @@
 	}
 
 	&.mixer-click-visual-click::after {
-		animation: anim-effect-subtle 0.3s ease-out forwards;		
+		animation: anim-effect-subtle 0.3s ease-out forwards;
 	}
 }
-  
+
 @-webkit-keyframes anim-effect-subtle {
 	0% {
 		opacity: 1;

--- a/src/prefabs/screen/screen.tsx
+++ b/src/prefabs/screen/screen.tsx
@@ -92,7 +92,7 @@ export class Screen extends PreactControl<any, IScreenState> {
     const { player: { top, left, width, height } } = this.state;
     return (
       <div class="screen-container">
-        {this.isXbox && <div id="xbox-cursor" style={this.state.cursorPosition} />}
+        {this.isXbox && <div id="xbox-cursor" tabIndex={0} style={this.state.cursorPosition} />}
         <div
           ref={this.setRippleRef}
           key={`screen-${controlID}`}


### PR DESCRIPTION
Small bug with gamepad input; no focusable element causes navigation events to not bubble properly.  This allows everything to work as expected.  We could listen to focusIn events on the rpc layer, but this is cleaner imo.